### PR TITLE
v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/goinsane/application
 
 go 1.7
+
+require (
+	github.com/goinsane/xcontext v1.5.4
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/goinsane/xcontext v1.4.1 h1:3h5Wl//AerANDdsOFfoOtXd1+UKH8xnZ0SYFnqzturw=
+github.com/goinsane/xcontext v1.4.1/go.mod h1:y+fK+cXBf9T6MBP7XFXQbYrsyhzlhRVVIIRVTxc6QjY=
+github.com/goinsane/xcontext v1.5.0 h1:DdVfHipJuhIIfhaQMGVRQ3rs5XOlg5+VKFixEXbuTyk=
+github.com/goinsane/xcontext v1.5.0/go.mod h1:y+fK+cXBf9T6MBP7XFXQbYrsyhzlhRVVIIRVTxc6QjY=
+github.com/goinsane/xcontext v1.5.1 h1:fQwJoWAP61bqsh1JAP42d6HMRFBYCdFw57TXlUToB8c=
+github.com/goinsane/xcontext v1.5.1/go.mod h1:y+fK+cXBf9T6MBP7XFXQbYrsyhzlhRVVIIRVTxc6QjY=
+github.com/goinsane/xcontext v1.5.2 h1:ocUAm9xdNmbb2fnx8sn1XplruwrtEPdsJtLrEW56CI8=
+github.com/goinsane/xcontext v1.5.2/go.mod h1:y+fK+cXBf9T6MBP7XFXQbYrsyhzlhRVVIIRVTxc6QjY=
+github.com/goinsane/xcontext v1.5.3 h1:tcQ66M7f2U9mLdIS02nvpJOj6gKylAGvp/V5IXl1LKc=
+github.com/goinsane/xcontext v1.5.3/go.mod h1:y+fK+cXBf9T6MBP7XFXQbYrsyhzlhRVVIIRVTxc6QjY=
+github.com/goinsane/xcontext v1.5.4 h1:sOBI7GgaXxeJjhKAZMJ++YZyf04YYdU+pjMt+UGCiX0=
+github.com/goinsane/xcontext v1.5.4/go.mod h1:y+fK+cXBf9T6MBP7XFXQbYrsyhzlhRVVIIRVTxc6QjY=


### PR DESCRIPTION
- used xcontext
- Context in package, is equal to xcontext.TerminateContext now
- terminateCtx that used in Application.Terminate, doesn't cancel when Run or RunAll are done
- Run and RunAll function return terminateCtx now